### PR TITLE
Change la description en français

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site Settings
-title: WeTry | Just another dev blog
+title: WeTry | Un autre blog de développeur
 email: info@wetry.tech
-description: Just another dev blog.
+description: Un autre blog de développeur.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://wetry.tech" # the base hostname & protocol for your site
 google_analytics: "UA-145445435-1"

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site Settings
-title: WeTry | Un autre blog de développeur
+title: WeTry | Encore un autre blog de développeur
 email: info@wetry.tech
-description: Un autre blog de développeur.
+description: Encore un autre blog de développeur.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://wetry.tech" # the base hostname & protocol for your site
 google_analytics: "UA-145445435-1"


### PR DESCRIPTION

Le but est de faire comprendre au partage du lien que le blog est francophone. La description en anglais induit en erreur dès la partage de la vignette