### PR TITLE
Table of Content déconne sur les longues lignes

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,10 +1,10 @@
 #markdown-toc, #markdown-toc ul, #markdown-toc ol, #markdown-toc li {
     font-size: 1rem;
-    line-height: 0.5rem;
+    line-height: 1rem;
 }
 
 #markdown-toc, #markdown-toc ul, #markdown-toc ol {
-    margin: 1rem auto 0;
+    margin: 0.5rem auto 0;
 }
 
 #markdown-toc {


### PR DESCRIPTION
Résout l'issue https://github.com/wetryio/jekyll-blog/issues/38.

Voir résultat ci dessous.

_Mobile_
![image](https://user-images.githubusercontent.com/23192591/64935104-4b5e5480-d84f-11e9-999e-4047d7658835.png)

_Browser_
![image](https://user-images.githubusercontent.com/23192591/64935113-67fa8c80-d84f-11e9-92bb-b47902063560.png)
